### PR TITLE
docs: add paper reproduction catalog to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,19 @@ For each case, keep the public boundary clear:
 - generated figures belong in `outputs/figures/`;
 - validation results belong in `outputs/checks/`;
 - paper/source references should be links or citations, not copied raw assets.
+
+## Before Opening a Pull Request
+
+Regenerate navigation after adding or changing a catalog entry:
+
+```bash
+python scripts/render_case_catalog.py
+```
+
+Then verify the public package:
+
+```bash
+python scripts/render_case_catalog.py --check
+python scripts/validate_public_cases.py
+python -m compileall -q scripts cases
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # RunThePaper
 
-RunThePaper is an open research reproduction project.
+**An open, inspectable library of paper reproductions.**
 
-We turn papers into readable reproduction notes, runnable code, checkable data,
-reproduced figures, and honest reproduction boundaries.
+Built with our self-developed paper reproduction Agent, RunThePaper turns
+papers into readable notes, runnable code, generated figures, and checkable
+evidence. The Agent4Science goal is to move from paper summarization to research
+that readers can run, audit, and extend.
 
 [Paper catalog](#paper-reproduction-catalog--论文复现目录) ·
+[What each case includes](#what-each-case-includes) ·
 [How to participate](#how-to-participate) ·
 [Project roadmap](ROADMAP.md) ·
 [Contributing guide](CONTRIBUTING.md)
@@ -32,114 +35,40 @@ directly to the bilingual notes, runnable code, and generated figures.
 For audit scores and reproduction boundaries, see the [detailed case index](CASES.md).
 <!-- case-catalog:end -->
 
-## What This Repository Is
+## What Each Case Includes
 
-This repository publishes the human-facing outputs of our paper reproduction
-work:
-
-- Chinese and English getting-started reproduction notes;
-- paper-derived numerical code;
+- Chinese and English reproduction notes;
+- runnable code and run commands;
 - generated data and figures;
-- validation checks and scorecards;
-- lessons learned from failed and successful reproduction attempts.
-
-RunThePaper is the public collaboration surface: readers can inspect, run,
-question, extend, and improve each case.
-
-## The Reproduction Agent Behind the Project
-
-RunThePaper is supported by a separate reproduction system, currently called
-PRAgent/RRAgent. The public project and the reproduction agent serve different
-roles: RunThePaper is the open case library; the agent is the execution engine
-used to produce and validate those cases.
-
-The longer-term Agent4Science goal is to move beyond AI systems that only read
-or summarize papers. A reproduction agent should be able to turn a paper into
-an executable and checkable workflow:
-
-1. identify the paper's claims, target figures, and required evidence;
-2. trace formulas, parameters, boundary conditions, and numerical methods;
-3. implement and run the calculation with the paper's final parameters;
-4. compare generated results against physical and numerical acceptance checks;
-5. record failures, uncertainty, and the remaining reproduction boundary.
-
-The reproduction notes in this repository are the human-readable entry points
-created from that execution process. Code, generated data, figures, and checks
-preserve the evidence behind each note. Across many papers, these real
-execution traces can also become useful evaluation and improvement data for
-scientific agents.
+- machine-readable checks, an audit score, and an explicit limitation statement;
+- derivation, numerical-method, and lessons-learned documents where relevant.
 
 ## How To Participate
-
-You can participate without working on the agent itself:
 
 - request a paper by providing its title, DOI or arXiv ID, and the figure or
   claim you most want reproduced;
 - run an existing case and report any environment, numerical, or documentation
   problem;
-- review formulas, parameters, code, checks, or reproduction boundaries;
-- extend a case and share what you learn from using it as a research baseline.
+- review or extend a case and share corrections, checks, or new results.
 
-Open a GitHub issue with enough context for another researcher to understand
-the target. Every concrete request, correction, and extension helps improve the
-public case library.
+Start by [opening an issue](https://github.com/xi-zhao/runthepaper/issues) with
+the paper and target result. You do not need to work on the Agent itself.
 
-## What This Repository Is Not
+## How To Read Reproduction Quality
 
-RunThePaper is not a paper PDF mirror, an arXiv source mirror, or a model
-training pack.
+Final public figures use the paper's parameters whenever public inputs and
+available resources make that possible. Otherwise the case is labeled as
+reduced-scale, subset, proxy, or blocked; a test-scale result is never presented
+as a complete reproduction.
 
-Original papers, publisher PDFs, arXiv source archives, and original figure
-assets are not redistributed here. When a case uses those materials for
-internal comparison, the public case records the evidence boundary and points
-readers back to the official paper source.
+The audit score measures the coverage of available evidence. It is not a
+percentage of physical correctness, a visual similarity rating, a cross-paper
+ranking, or a publication threshold. Read the status and limitation statement
+together with the score.
 
-## Repository Structure
-
-```text
-cases/
-  <paper-id>/
-    README.md              # public case overview
-    note/                  # Chinese and English getting-started notes
-    code/                  # runnable reproduction code
-    docs/                  # derivation, methods, scorecards, lessons
-    outputs/
-      data/                # generated CSV data
-      figures/             # generated figures
-      checks/              # validation JSON
-```
-
-## Reproduction Boundary
-
-Each case separates:
-
-- paper claims from our reproduction claims;
-- generated numerical data from reference data;
-- feature-level reproduction from author-data-level reproduction;
-- scientific agreement from visual styling similarity;
-- successful reproduction from remaining gaps.
-
-This is the core rule of RunThePaper: do not hide uncertainty.
-
-## Publication Contract
-
-A case is ready to publish when it has both Chinese and English notes, runnable
-public scripts, generated outputs, machine-readable checks, and an explicit
-limitation statement. The audit score is supporting evidence, not a publishing
-threshold.
-
-Final figures use the paper's parameters whenever local resources and public
-inputs make that possible. If a paper-scale run is not feasible, the case must
-be labeled as reduced-scale, subset, proxy, or blocked; a test-scale result must
-not be presented as a complete reproduction.
-
-Maintainers can verify the public package with:
-
-```bash
-python scripts/render_case_catalog.py --check
-python scripts/validate_public_cases.py
-python -m compileall -q scripts cases
-```
+Original paper PDFs, source archives, figures, and extracted plotting data are
+not redistributed here. Each case links to the official paper and states its
+remaining reproduction boundary.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,33 @@ RunThePaper is an open research reproduction project.
 We turn papers into readable reproduction notes, runnable code, checkable data,
 reproduced figures, and honest reproduction boundaries.
 
+[Paper catalog](#paper-reproduction-catalog--论文复现目录) ·
+[How to participate](#how-to-participate) ·
+[Project roadmap](ROADMAP.md) ·
+[Contributing guide](CONTRIBUTING.md)
+
+## Paper Reproduction Catalog / 论文复现目录
+
+<!-- case-catalog:start -->
+**10 published cases.** Choose a paper below to open its case overview or go
+directly to the bilingual notes, runnable code, and generated figures.
+
+| Paper | Research topic | Reproduction status | Open resources |
+| --- | --- | --- | --- |
+| [Edge states and topological invariants of non-Hermitian systems](cases/1803.01876/README.md)<br>[Physical Review Letters 121, 086803 (2018)](https://doi.org/10.1103/PhysRevLett.121.086803) | Non-Hermitian SSH model and non-Bloch bulk-boundary correspondence | Paper-parameter complete reproduction | [中文 Note](cases/1803.01876/note/reproduction-note.zh-CN.md) · [English Note](cases/1803.01876/note/reproduction-note.en.md)<br>[Code](cases/1803.01876/code/README.md) · [Figures](cases/1803.01876/outputs/figures/) |
+| [Non-Hermitian Chern bands](cases/1804.04672/README.md)<br>[arXiv:1804.04672](https://arxiv.org/abs/1804.04672) | Non-Hermitian Chern bands and non-Bloch Chern physics | Feature-level reproduction | [中文 Note](cases/1804.04672/note/reproduction-note.zh-CN.md) · [English Note](cases/1804.04672/note/reproduction-note.en.md)<br>[Code](cases/1804.04672/code/README.md) · [Figures](cases/1804.04672/outputs/figures/) |
+| [Tackling the Qubit Mapping Problem for NISQ-Era Quantum Devices](cases/10.1145-3297858.3304023/README.md)<br>[DOI:10.1145-3297858.3304023](https://doi.org/10.1145/3297858.3304023) | SABRE qubit mapping and routing | Feature-level reproduction with partial benchmark coverage | [中文 Note](cases/10.1145-3297858.3304023/note/reproduction-note.zh-CN.md) · [English Note](cases/10.1145-3297858.3304023/note/reproduction-note.en.md)<br>[Code](cases/10.1145-3297858.3304023/code/README.md) · [Figures](cases/10.1145-3297858.3304023/outputs/figures/) |
+| [Discrete time crystals: rigidity, criticality, and realizations](cases/1608.02589/README.md)<br>[arXiv:1608.02589](https://arxiv.org/abs/1608.02589) | Floquet many-body dynamics and discrete time crystals | Reduced-scale feature reproduction | [中文 Note](cases/1608.02589/note/reproduction-note.zh-CN.md) · [English Note](cases/1608.02589/note/reproduction-note.en.md)<br>[Code](cases/1608.02589/code/README.md) · [Figures](cases/1608.02589/outputs/figures/) |
+| [Quantum many-body scars](cases/1711.03528/README.md)<br>[arXiv:1711.03528](https://arxiv.org/abs/1711.03528) | PXP dynamics and quantum many-body scars | Reduced-scale feature reproduction | [中文 Note](cases/1711.03528/note/reproduction-note.zh-CN.md) · [English Note](cases/1711.03528/note/reproduction-note.en.md)<br>[Code](cases/1711.03528/code/README.md) · [Figures](cases/1711.03528/outputs/figures/) |
+| [Simulating the Sycamore quantum supremacy circuits](cases/2103.03074/README.md)<br>[arXiv:2103.03074](https://arxiv.org/abs/2103.03074) | Sycamore random-circuit simulation | Reduced-scale feature reproduction | [中文 Note](cases/2103.03074/note/reproduction-note.zh-CN.md) · [English Note](cases/2103.03074/note/reproduction-note.en.md)<br>[Code](cases/2103.03074/code/README.md) · [Figures](cases/2103.03074/outputs/figures/) |
+| [Efficient simulation of logical magic state preparation protocols](cases/2512.23799/README.md)<br>[arXiv:2512.23799](https://arxiv.org/abs/2512.23799) | Logical magic-state preparation simulation | Partial feature reproduction | [中文 Note](cases/2512.23799/note/reproduction-note.zh-CN.md) · [English Note](cases/2512.23799/note/reproduction-note.en.md)<br>[Code](cases/2512.23799/code/README.md) · [Figures](cases/2512.23799/outputs/figures/) |
+| [An Algorithm for Fast Assembling Large-Scale Defect-Free Atom Arrays](cases/2604.08669/README.md)<br>[arXiv:2604.08669](https://arxiv.org/abs/2604.08669) | Defect-free atom-array assembly | Reduced-scale feature reproduction | [中文 Note](cases/2604.08669/note/reproduction-note.zh-CN.md) · [English Note](cases/2604.08669/note/reproduction-note.en.md)<br>[Code](cases/2604.08669/code/README.md) · [Figures](cases/2604.08669/outputs/figures/) |
+| [Boson Sampling as a Probe of Chaotic and Integrable Quantum Dynamics](cases/2605.25398/README.md)<br>[arXiv:2605.25398](https://arxiv.org/abs/2605.25398) | Boson sampling and quantum-chaos probes | Feature-level reproduction | [中文 Note](cases/2605.25398/note/reproduction-note.zh-CN.md) · [English Note](cases/2605.25398/note/reproduction-note.en.md)<br>[Code](cases/2605.25398/code/README.md) · [Figures](cases/2605.25398/outputs/figures/) |
+| [Sensitivity to perturbations in the three-dimensional Anderson model](cases/2605.25594/README.md)<br>[arXiv:2605.25594](https://arxiv.org/abs/2605.25594) | Three-dimensional Anderson localization | Reduced-scale feature reproduction | [中文 Note](cases/2605.25594/note/reproduction-note.zh-CN.md) · [English Note](cases/2605.25594/note/reproduction-note.en.md)<br>[Code](cases/2605.25594/code/README.md) · [Figures](cases/2605.25594/outputs/figures/) |
+
+For audit scores and reproduction boundaries, see the [detailed case index](CASES.md).
+<!-- case-catalog:end -->
+
 ## What This Repository Is
 
 This repository publishes the human-facing outputs of our paper reproduction
@@ -66,29 +93,6 @@ Original papers, publisher PDFs, arXiv source archives, and original figure
 assets are not redistributed here. When a case uses those materials for
 internal comparison, the public case records the evidence boundary and points
 readers back to the official paper source.
-
-## Start Here
-
-RunThePaper currently publishes 10 inspectable reproduction cases across
-non-Hermitian physics, many-body dynamics, quantum circuits, atom-array
-assembly, boson sampling, and localization.
-
-### Featured case: PRL 121, 086803 (2018)
-
-The `1803.01876` case reproduces the open-boundary spectrum, generalized
-Brillouin zone, skin profiles, non-Bloch winding, and the nonzero-`t3`
-extension with the paper's final parameters.
-
-- [Case overview and four main reproduced figures](cases/1803.01876/README.md)
-- [中文复现 Note](cases/1803.01876/note/reproduction-note.zh-CN.md)
-- [English reproduction note](cases/1803.01876/note/reproduction-note.en.md)
-- [Runnable code](cases/1803.01876/code/README.md)
-
-Browse the project:
-
-- [All published cases](CASES.md)
-- [Project roadmap](ROADMAP.md)
-- [How to contribute](CONTRIBUTING.md)
 
 ## Repository Structure
 

--- a/scripts/render_case_catalog.py
+++ b/scripts/render_case_catalog.py
@@ -8,6 +8,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 CATALOG_PATH = ROOT / "cases" / "catalog.json"
+README_CATALOG_START = "<!-- case-catalog:start -->"
+README_CATALOG_END = "<!-- case-catalog:end -->"
 
 
 def load_catalog() -> list[dict[str, Any]]:
@@ -18,6 +20,56 @@ def load_catalog() -> list[dict[str, Any]]:
     if not isinstance(cases, list) or not cases:
         raise ValueError("catalog must contain cases")
     return [item for item in cases if isinstance(item, dict)]
+
+
+def paper_reference(case: dict[str, Any]) -> str:
+    if case.get("publication") and case.get("doi_url"):
+        return f"[{case['publication']}]({case['doi_url']})"
+    paper_id = str(case["paper_id"])
+    if paper_id.startswith("10."):
+        return f"[DOI:{paper_id}]({case['paper_url']})"
+    return f"[arXiv:{paper_id}]({case['paper_url']})"
+
+
+def render_readme_catalog(cases: list[dict[str, Any]]) -> str:
+    lines = [
+        f"**{len(cases)} published cases.** Choose a paper below to open its case overview or go",
+        "directly to the bilingual notes, runnable code, and generated figures.",
+        "",
+        "| Paper | Research topic | Reproduction status | Open resources |",
+        "| --- | --- | --- | --- |",
+    ]
+    for case in cases:
+        paper_id = str(case["paper_id"])
+        case_root = f"cases/{paper_id}"
+        paper = f"[{case['title']}]({case_root}/README.md)<br>{paper_reference(case)}"
+        resources = (
+            f"[中文 Note]({case_root}/note/reproduction-note.zh-CN.md) · "
+            f"[English Note]({case_root}/note/reproduction-note.en.md)<br>"
+            f"[Code]({case_root}/code/README.md) · "
+            f"[Figures]({case_root}/outputs/figures/)"
+        )
+        lines.append(
+            f"| {paper} | {case['topic']} | {case['status']} | {resources} |"
+        )
+    lines.extend(
+        [
+            "",
+            "For audit scores and reproduction boundaries, see the [detailed case index](CASES.md).",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_root_readme(cases: list[dict[str, Any]]) -> str:
+    path = ROOT / "README.md"
+    content = path.read_text(encoding="utf-8")
+    if content.count(README_CATALOG_START) != 1 or content.count(README_CATALOG_END) != 1:
+        raise ValueError("README.md must contain exactly one generated case-catalog block")
+    start = content.index(README_CATALOG_START) + len(README_CATALOG_START)
+    end = content.index(README_CATALOG_END, start)
+    generated = "\n" + render_readme_catalog(cases) + "\n"
+    return content[:start] + generated + content[end:]
 
 
 def render_cases_index(cases: list[dict[str, Any]]) -> str:
@@ -195,7 +247,10 @@ def render_note_index(case: dict[str, Any]) -> str:
 
 
 def expected_files(cases: list[dict[str, Any]]) -> dict[Path, str]:
-    rendered = {ROOT / "CASES.md": render_cases_index(cases)}
+    rendered = {
+        ROOT / "README.md": render_root_readme(cases),
+        ROOT / "CASES.md": render_cases_index(cases),
+    }
     for case in cases:
         case_dir = ROOT / "cases" / str(case["paper_id"])
         if not case_dir.exists():


### PR DESCRIPTION
## What changed

- add all published papers directly to the repository README
- link each paper to its case overview, bilingual notes, runnable code, and generated figures
- generate the README catalog from cases/catalog.json
- reduce the reader-facing README from 177 lines to 80 lines
- move maintainer verification commands to CONTRIBUTING.md

## Reader impact

The repository now opens with the project position and complete paper catalog. It keeps only the information readers need to find, understand, assess, request, or extend a reproduction.

## Validation

- python scripts/render_case_catalog.py --check
- python scripts/validate_public_cases.py
- python -m compileall -q scripts cases
- git diff --check